### PR TITLE
Miscellaneous bug fixes 

### DIFF
--- a/src/export_postprocessor.cpp
+++ b/src/export_postprocessor.cpp
@@ -20,6 +20,7 @@ using namespace synaptics::synap;
 
 
 PYBIND11_MAKE_OPAQUE(vector<Detector::Result::Item>);
+PYBIND11_MAKE_OPAQUE(vector<Classifier::Result::Item>);
 
 static void export_postprocessor(py::module_& m)
 {

--- a/src/export_tensor.cpp
+++ b/src/export_tensor.cpp
@@ -287,9 +287,8 @@ static void export_tensors(py::module_& m)
     .def(
         "__iter__",
         [](Tensors& ts) -> py::iterator {
-            return py::make_iterator(ts.begin(), ts.end());
+            return py::make_iterator(ts.begin(), ts.end(), py::return_value_policy::reference);
         },
-        py::return_value_policy::reference,
         "Iterate over tensors"
     )
     ;

--- a/src/export_tensor.cpp
+++ b/src/export_tensor.cpp
@@ -257,7 +257,7 @@ static void export_tensors(py::module_& m)
 
             return np_array.reshape(self.shape());
         },
-        "Get tensor data as NumPy array"
+        "Get dequantized tensor data as NumPy array"
     )
     ;
 

--- a/src/export_tensor.cpp
+++ b/src/export_tensor.cpp
@@ -143,6 +143,11 @@ static void export_tensors(py::module_& m)
         "Get tensor name"
     )
     .def_property_readonly(
+        "is_scalar",
+        &Tensor::is_scalar,
+        "Check if tensor is a scalar"
+    )
+    .def_property_readonly(
         "layout",
         &Tensor::layout,
         "Get tensor layout"

--- a/src/export_tensor.cpp
+++ b/src/export_tensor.cpp
@@ -263,9 +263,6 @@ static void export_tensors(py::module_& m)
 
     /* Tensors */
     py::class_<Tensors>(m, "Tensors")
-    .def(
-        py::init<vector<Tensor> &>()
-    )
     .def_property_readonly(
         "size", &Tensors::size, "Get tensors size"
     )

--- a/src/synap/__init__.pyi
+++ b/src/synap/__init__.pyi
@@ -106,6 +106,11 @@ class Tensor:
         Get number of items in tensor
         """
     @property
+    def is_scalar(self) -> bool:
+        """
+        Check if tensor is scalar
+        """
+    @property
     def layout(self) -> types.Layout:
         """
         Get tensor layout


### PR DESCRIPTION
- Remove faulty constructor for `synap.Tensors` (668fba910c21b2c5ad9f089bf72f04ce522f1b03)
- Fix return policy for `synap.Tensors.__iter__` (8a28d40dfe15014383b8b1ee7cfec532f408b32b)
- Update docstring for `synapTensor.to_numpy()` to specify that returned array is denormalized (4a2cc068ec7f8b59d57649cd08349fd3dd95f63d)
- Add `PYBIND11_MAKE_OPAQUE` to `synap.postprocessor.ResultItem` (d66bd6930db2af5b3eab166444e51a2a34ca8bb1)