### PR TITLE
Optimize build scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,11 +9,8 @@ PYTHON_DEV_URL="https://github.com/tttapa/python-dev/releases/download/0.0.7/pyt
 TOOLCHAIN_URL="https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-linux-gnu.tar.xz"
 
 ROOT_DIR="$PWD"
-PYBIND11_DIR="$ROOT_DIR/extern/pybind11"
-VENV_DIR="$ROOT_DIR/.venv"
 BUILD_DIR="$ROOT_DIR/build"
 CACHE_DIR="$ROOT_DIR/.py-build-cmake_cache"
-DIST_DIR="$ROOT_DIR/dist"
 
 VERBOSE=false
 CLEAN=false
@@ -52,6 +49,11 @@ done
 
 TARGET_ARCH="aarch64"
 HOST_ARCH=$(uname -m)
+
+if [[ "$HOST_ARCH" != "x86_64" && "$HOST_ARCH" != "aarch64" ]]; then
+    echo "Error: Unsupported architecture '$HOST_ARCH'."
+    exit 1
+fi
 
 if [[ "$x86_64" == true && "$HOST_ARCH" != "x86_64" ]]; then
     echo "Error: Cannot build for x86_64 on arch $HOST_ARCH"
@@ -136,6 +138,10 @@ build_extensions() {
     fi
 }
 
+generate_stubs() {
+    bash "$ROOT_DIR/stubs.sh"
+}
+
 TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 LOG_DIR="$ROOT_DIR/logs/$TIMESTAMP"
 mkdir -p "$LOG_DIR"
@@ -172,6 +178,12 @@ else
     fi
 fi
 run_cmd "build_extensions" "Building Python extensions" "$LOG_DIR/build_extensions.log"
+
+if $CROSSCOMPILE; then
+    echo "Skipping stubs generation for cross-compilation"
+else
+    run_cmd "generate_stubs" "Generating stubs" "$LOG_DIR/stubgen.log"
+fi
 
 echo -e "\033[32mBuild completed successfully, wheel located at $ROOT_DIR/dist/\033[0m"
 

--- a/docs/gen_docs.sh
+++ b/docs/gen_docs.sh
@@ -8,12 +8,13 @@ set -e
 SYNAP_VERSION="0.0.3"
 SYNAP_RELEASE="preview"
 DOCS_ROOT="$PWD"
+ROOT_DIR="$DOCS_ROOT/.."
 VENV_DIR="$DOCS_ROOT/.docs"
-DIST_DIR="$DOCS_ROOT/../dist"
+DIST_DIR="$ROOT_DIR/dist"
+HOST_ARCH=$(uname -m)
 
 cleanup() {
     if [ -n "$VIRTUAL_ENV" ]; then
-        echo "Deactivating virtual environment..."
         deactivate
     fi
 }
@@ -32,28 +33,22 @@ if [ ! -d "$VENV_DIR" ]; then
     pip install --upgrade pip
     pip install build sphinx sphinx-markdown-builder sphinx-rtd-theme wheel
 fi
-echo "Activating virtual environment..."
 source "$VENV_DIR/bin/activate"
 
 echo "Installing latest SyNAP Python API wheel..."
-arch=$(uname -m)
-cd "$DOCS_ROOT/.."
-if [ "$arch" = "x86_64" ]; then
-    bash ./build.sh --clean --x86_64
-    wheel="$DIST_DIR/synap_python-$SYNAP_VERSION-cp310-cp310-linux_x86_64.whl"
-elif [ "$arch" = "aarch64" ]; then
-    bash ./build.sh --clean
-    wheel="$DIST_DIR/synap_python-$SYNAP_VERSION-cp310-cp310-linux_aarch64.whl"
-else
-    echo "Error: Unsupported architecture '$arch'."
+PY_WHL="$DIST_DIR/synap_python-$SYNAP_VERSION-cp310-cp310-linux_$HOST_ARCH.whl"
+if [ ! -f "$PY_WHL" ]; then
+    echo -e "\033[31mError: Wheel file for $HOST_ARCH not found\033[0m"
+    if [ "$HOST_ARCH" == "x86_64" ]; then
+        echo -e "       \033[31mBuild wheel with $ROOT_DIR/build.sh --x86_64\033[0m"
+    elif [ "$HOST_ARCH" == "aarch64" ]; then
+        echo -e "       \033[31mBuild wheel with $ROOT_DIR/build.sh\033[0m"
+    else
+        echo -e "       \033[31mError: Unsupported architecture '$HOST_ARCH'\033[0m"
+    fi
     exit 1
 fi
-
-if [ ! -f "$wheel" ]; then
-    echo "Error: SyNAP Python API wheel not found at '$wheel'."
-    exit 1
-fi
-pip install --force-reinstall "$wheel"
+pip install --force-reinstall "$PY_WHL"
 
 cd $DOCS_ROOT
 echo "Building documentation..."
@@ -61,3 +56,4 @@ mkdir -p source/_static
 make clean
 sphinx-build -b markdown source build/markdown
 find "build/markdown" -type f -name "*.md" -exec sed -i "s/synap\._synap/synap/g" {} +
+echo -e "\033[32mDocs generated successfully\033[0m"

--- a/docs/gen_docs.sh
+++ b/docs/gen_docs.sh
@@ -26,14 +26,15 @@ if [ "$(basename "$DOCS_ROOT")" != "docs" ]; then
     exit 1
 fi
 if [ ! -d "$VENV_DIR" ]; then
-    echo "Creating virtual environment..."
+    echo "Creating virtual environment $VENV_DIR..."
     python3 -m venv "$VENV_DIR"
-    source "$VENV_DIR/bin/activate"
-    echo "Installing pip packages..."
-    pip install --upgrade pip
-    pip install build sphinx sphinx-markdown-builder sphinx-rtd-theme wheel
 fi
 source "$VENV_DIR/bin/activate"
+echo "Generating docs in virtual environment $VENV_DIR"
+
+echo "Installing Sphinx and dependencies..."
+pip install --upgrade pip > /dev/null
+pip install build sphinx sphinx-markdown-builder sphinx-rtd-theme wheel > /dev/null
 
 echo "Installing latest SyNAP Python API wheel..."
 PY_WHL="$DIST_DIR/synap_python-$SYNAP_VERSION-cp310-cp310-linux_$HOST_ARCH.whl"
@@ -48,7 +49,7 @@ if [ ! -f "$PY_WHL" ]; then
     fi
     exit 1
 fi
-pip install --force-reinstall "$PY_WHL"
+pip install --force-reinstall "$PY_WHL" > /dev/null
 
 cd $DOCS_ROOT
 echo "Building documentation..."

--- a/stubs.sh
+++ b/stubs.sh
@@ -25,14 +25,15 @@ trap cleanup EXIT
 cd "$ROOT_DIR"
 
 if [ ! -d "$VENV_DIR" ]; then
+    echo "Creating virtual environment $VENV_DIR..."
     python3 -m venv "$VENV_DIR"
 fi
 source "$VENV_DIR/bin/activate"
-echo "Generating stubs in isolated environment $VIRTUAL_ENV"
+echo "Generating stubs in virtual environment $VENV_DIR"
 
-echo "Installing pip packages..."
-pip install --upgrade pip
-pip install pybind11 pybind11-stubgen py-build-cmake typing-extensions numpy
+echo "Installing pybind11-stubgen and dependencies..."
+pip install --upgrade pip > /dev/null
+pip install pybind11 pybind11-stubgen py-build-cmake typing-extensions numpy > /dev/null
 
 PY_WHL="$DIST_DIR/synap_python-$SYNAP_VERSION-cp310-cp310-linux_$HOST_ARCH.whl"
 if [ ! -f "$PY_WHL" ]; then
@@ -46,8 +47,9 @@ if [ ! -f "$PY_WHL" ]; then
     fi
     exit 1
 fi
-pip install --force-reinstall "$PY_WHL"
+pip install --force-reinstall "$PY_WHL" > /dev/null
 
+echo "Generating stubs..."
 mkdir -p "$STUBGEN_DIR/synap"
 pybind11-stubgen synap \
     -o "$OUTPUT_DIR" \

--- a/stubs.sh
+++ b/stubs.sh
@@ -6,20 +6,18 @@
 set -e
 
 ROOT_DIR="$PWD"
-VENV_DIR="$ROOT_DIR/.stubgen"
+VENV_DIR="$ROOT_DIR/.stubs"
+DIST_DIR="$ROOT_DIR/dist"
 SRC_DIR="$ROOT_DIR/src/synap"
-BUILD_CONFIG="$ROOT_DIR/build/x86_64-linux-gnu.python3.10.py-build-cmake.local.toml"
-BUILD_CACHE="$ROOT_DIR/.py-build-cmake_cache/cp310-cp310-linux_x86_64-x86_64-linux-gnu"
 STUBGEN_DIR="$ROOT_DIR/stubgen"
 OUTPUT_DIR="$STUBGEN_DIR/stubs"
 STUBS_DIR="$OUTPUT_DIR/synap/_synap"
-SYNAP_MODULE="synap._synap"
+SYNAP_VERSION="0.0.3"
+HOST_ARCH=$(uname -m)
 
 cleanup() {
     if [ -n "$VIRTUAL_ENV" ]; then
-        echo "Deactivating and removing virtual environment..."
         deactivate
-        rm -rf "$VENV_DIR"
     fi
 }
 trap cleanup EXIT
@@ -36,15 +34,22 @@ echo "Installing pip packages..."
 pip install --upgrade pip
 pip install pybind11 pybind11-stubgen py-build-cmake typing-extensions numpy
 
-rm -rf $BUILD_CACHE
-echo "Configuring build..."
-py-build-cmake --local "$BUILD_CONFIG" configure
-echo "Building extension..."
-py-build-cmake --local "$BUILD_CONFIG" build
+PY_WHL="$DIST_DIR/synap_python-$SYNAP_VERSION-cp310-cp310-linux_$HOST_ARCH.whl"
+if [ ! -f "$PY_WHL" ]; then
+    echo -e "\033[31mError: Wheel file for $HOST_ARCH not found\033[0m"
+    if [ "$HOST_ARCH" == "x86_64" ]; then
+        echo -e "       \033[31mBuild wheel with $ROOT_DIR/build.sh --x86_64\033[0m"
+    elif [ "$HOST_ARCH" == "aarch64" ]; then
+        echo -e "       \033[31mBuild wheel with $ROOT_DIR/build.sh\033[0m"
+    else
+        echo -e "       \033[31mError: Unsupported architecture '$HOST_ARCH'\033[0m"
+    fi
+    exit 1
+fi
+pip install --force-reinstall "$PY_WHL"
 
 mkdir -p "$STUBGEN_DIR/synap"
-cp "$BUILD_CACHE/_synap.cpython-310-x86_64-linux-gnu.so" "$STUBGEN_DIR/synap/"
-PYTHONPATH="$STUBGEN_DIR:$PYTHONPATH" pybind11-stubgen "$SYNAP_MODULE" \
+pybind11-stubgen synap \
     -o "$OUTPUT_DIR" \
     --enum-class-locations \
         Layout:synap._synap.types \
@@ -58,3 +63,4 @@ cp "$STUBS_DIR/__init__.pyi" "$SRC_DIR/__init__.pyi"
 cp "$STUBS_DIR/preprocessor.pyi" "$SRC_DIR/preprocessor/__init__.pyi"
 cp "$STUBS_DIR/postprocessor.pyi" "$SRC_DIR/postprocessor/__init__.pyi"
 cp "$STUBS_DIR/types.pyi" "$SRC_DIR/types/__init__.pyi"
+echo -e "\033[32mStubs generated successfully\033[0m"


### PR DESCRIPTION
* Remove build steps from `stubs.sh` and `docs/gen_docs.sh` to prevent build cache corruption
* Add automatic stub generation to `build.sh` when not cross-compiling